### PR TITLE
Update to java 8 to enable TLS1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,22 @@ MAINTAINER KBase Developer
 
 # RUN apt-get update
 
+# update java
+RUN add-apt-repository ppa:openjdk-r/ppa \
+	&& sudo apt-get update \
+	&& sudo apt-get -y install openjdk-8-jdk \
+	&& echo java versions: \
+	&& java -version \
+	&& javac -version \
+	&& echo $JAVA_HOME \
+	&& ls -l /usr/lib/jvm \
+	&& cd /kb/runtime \
+	&& rm java \
+	&& ln -s /usr/lib/jvm/java-8-openjdk-amd64 java \
+	&& ls -l
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
 # update jars
 RUN cd /kb/dev_container/modules/jars \
 	&& git pull \
@@ -20,12 +36,6 @@ RUN mkdir -p /kb/module/work
 RUN chmod 777 /kb/module
 
 WORKDIR /kb/module
-
-# Fix for problem with lets-encript in Java (PKIX path building failed:
-#   sun.security.provider.certpath.SunCertPathBuilderException: unable
-#   to find valid certification path to requested target)
-RUN keytool -import -keystore /usr/lib/jvm/java-7-oracle/jre/lib/security/cacerts -storepass changeit -noprompt \
-    -trustcacerts -alias letsencryptauthorityx3 -file ./ssl/lets-encrypt-x3-cross-signed.der
 
 RUN make all
 


### PR DESCRIPTION
Lets encrypt hack no longer needed, removed.

Tested on appdev (TLS 1.0 - 1.2) without change - passed.
Tested on CI (TLS 1.2 only) without change - failed.
Tested on CI with change - passed.